### PR TITLE
fail fast if auth doesn't work

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -6,7 +6,6 @@ on:
       - main
   workflow_dispatch:
 
-
 jobs:
   build:
     name: Build stage2 packages
@@ -24,6 +23,22 @@ jobs:
           echo ::set-output name=date::$(date -u +%Y%m%d)
           echo ::set-output name=epoch::$(date -u +%s)
         shell: bash
+
+      - id: auth
+        name: 'Authenticate to Google Cloud'
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: "projects/567187841907/locations/global/workloadIdentityPools/staging-shared-9bd2/providers/staging-shared-gha"
+          service_account: "staging-images-ci@staging-images-183e.iam.gserviceaccount.com"
+
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: staging-images-183e
+
+      - name: 'Check that GCloud is properly configured'
+        run: |
+          gcloud info
+          gcloud ls
 
       - uses: actions/checkout@v3
       - run: echo "${{ secrets.MELANGE_RSA }}" > ./melange.rsa
@@ -78,21 +93,6 @@ jobs:
       - uses: chainguard-dev/actions/inky-build-pkg@main
         with:
           package-name: xz
-
-      - id: auth
-        name: 'Authenticate to Google Cloud'
-        uses: google-github-actions/auth@v0
-        with:
-          workload_identity_provider: "projects/567187841907/locations/global/workloadIdentityPools/staging-shared-9bd2/providers/staging-shared-gha"
-          service_account: "staging-images-ci@staging-images-183e.iam.gserviceaccount.com"
-
-      - uses: google-github-actions/setup-gcloud@v0
-        with:
-          project_id: staging-images-183e
-
-      - name: 'Check that GCloud is properly configured'
-        run: |
-          gcloud info
 
       - name: 'Upload the repository to a bucket'
         run: |


### PR DESCRIPTION
This moves gcloud setup earlier in the workflow, and checks that auth works with a `gsutil ls`.

If this works out I'll make the same change in stage1